### PR TITLE
헤더뷰, 메뉴뷰 오토 레이아웃 수정

### DIFF
--- a/DaumWebtoon/Controllers/Main/MainViewController.swift
+++ b/DaumWebtoon/Controllers/Main/MainViewController.swift
@@ -28,6 +28,7 @@ class MainViewController: UIViewController {
     private var scrollDirection: Direction?
     private var tabBarViewCenterYAnchorConstraint: NSLayoutConstraint?
     private var tabBarViewTopAnchorConstraint: NSLayoutConstraint?
+    private var headerViewTopAnchorConstraint: NSLayoutConstraint?
     private let menuViewHeight: CGFloat = 80
     private lazy var tabBarViewWidth: CGFloat = view.frame.width - 20
     private lazy var tabBarViewHeight: CGFloat = 30
@@ -109,7 +110,8 @@ extension MainViewController {
     
     func setHeaderViewLayout() {
         headerView.translatesAutoresizingMaskIntoConstraints = false
-        headerView.topAnchor.constraint(equalTo: menuView.bottomAnchor).isActive = true
+        headerViewTopAnchorConstraint = headerView.topAnchor.constraint(equalTo: menuView.bottomAnchor)
+        headerViewTopAnchorConstraint?.isActive = true
         headerView.bottomAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         headerView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         headerView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
@@ -350,11 +352,16 @@ extension MainViewController {
             sender.setTranslation(CGPoint.zero, in: scrollView)
         }
         updateHeaderViewAlpha(topLimit: topLimit, currentTabBarViewCenterYConstant: currentTabBarViewCenterYConstant)
+        updateHeaderViewTopAnchorConstraint(currentTabBarViewCenterYConstant: currentTabBarViewCenterYConstant)
     }
     
     func updateHeaderViewAlpha(topLimit: CGFloat, currentTabBarViewCenterYConstant: CGFloat) {
         let headerViewHeight = -topLimit
         headerView.alpha = (currentTabBarViewCenterYConstant - topLimit) / headerViewHeight
+    }
+    
+    func updateHeaderViewTopAnchorConstraint(currentTabBarViewCenterYConstant: CGFloat) {
+        headerViewTopAnchorConstraint?.constant = currentTabBarViewCenterYConstant / 2
     }
     
     @objc func searchTapped(_ sender: UIButton) {

--- a/DaumWebtoon/Controllers/Main/MainViewController.swift
+++ b/DaumWebtoon/Controllers/Main/MainViewController.swift
@@ -27,9 +27,8 @@ class MainViewController: UIViewController {
     private let genres: [Genre?] = [nil, .webDesign, .programming, .vrAndAr, .startup, nil]
     private var scrollDirection: Direction?
     private var tabBarViewCenterYAnchorConstraint: NSLayoutConstraint?
-    private var tabBarViewTopAnchorConstraint: NSLayoutConstraint?
     private var headerViewTopAnchorConstraint: NSLayoutConstraint?
-    private let menuViewHeight: CGFloat = 80
+    private let menuViewHeight: CGFloat = 70
     private lazy var tabBarViewWidth: CGFloat = view.frame.width - 20
     private lazy var tabBarViewHeight: CGFloat = 30
     private var lastContentOffset: CGFloat = 0
@@ -179,8 +178,7 @@ extension MainViewController {
         tabBarViewCenterYAnchorConstraint?.priority = .defaultLow
         tabBarViewCenterYAnchorConstraint?.isActive = true
         tabBarViewContainer.centerYAnchor.constraint(lessThanOrEqualTo: view.centerYAnchor).isActive = true
-        tabBarViewContainer.centerYAnchor.constraint(greaterThanOrEqualTo: view.topAnchor, constant: menuViewHeight + tabBarViewHeight).isActive = true
-        tabBarViewTopAnchorConstraint?.isActive = true
+        tabBarViewContainer.centerYAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: menuViewHeight + (tabBarViewHeight / 2)).isActive = true
     }
     
     func setTabBarViewProperties() {
@@ -259,7 +257,7 @@ extension MainViewController {
         menuView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
         menuView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         menuView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-        menuView.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        menuView.heightAnchor.constraint(equalToConstant: menuViewHeight).isActive = true
     }
     
     func setupSearchView() {
@@ -269,9 +267,9 @@ extension MainViewController {
         menuView.addSubview(search)
         
         search.translatesAutoresizingMaskIntoConstraints = false
-        search.widthAnchor.constraint(equalToConstant: 24).isActive = true
-        search.heightAnchor.constraint(equalToConstant: 24).isActive = true
-        search.trailingAnchor.constraint(equalTo: menuView.trailingAnchor, constant: -50).isActive = true
+        search.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        search.heightAnchor.constraint(equalToConstant: 30).isActive = true
+        search.trailingAnchor.constraint(equalTo: menuView.trailingAnchor, constant: -70).isActive = true
         search.centerYAnchor.constraint(equalTo: menuView.centerYAnchor).isActive = true
     }
     
@@ -282,9 +280,9 @@ extension MainViewController {
         menuView.addSubview(hamberger)
         
         hamberger.translatesAutoresizingMaskIntoConstraints = false
-        hamberger.widthAnchor.constraint(equalToConstant: 24).isActive = true
-        hamberger.heightAnchor.constraint(equalToConstant: 24).isActive = true
-        hamberger.trailingAnchor.constraint(equalTo: menuView.trailingAnchor, constant: -10).isActive = true
+        hamberger.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        hamberger.heightAnchor.constraint(equalToConstant: 30).isActive = true
+        hamberger.trailingAnchor.constraint(equalTo: menuView.trailingAnchor, constant: -18).isActive = true
         hamberger.centerYAnchor.constraint(equalTo: menuView.centerYAnchor).isActive = true
     }
     
@@ -341,7 +339,7 @@ extension MainViewController {
         guard let direction = scrollDirection,
             let currentTabBarViewCenterYConstant = tabBarViewCenterYAnchorConstraint?.constant,
             (direction == .up || direction == .down) else { return }
-        let topLimit = menuViewHeight + tabBarViewHeight - (scrollView.frame.height / 2)
+        let topLimit = menuViewHeight + (tabBarViewHeight / 2) - (scrollView.frame.height / 2)
         if currentTabBarViewCenterYConstant >= CGFloat(0), direction == .down {
             tabBarViewCenterYAnchorConstraint?.constant = 0
         } else if currentTabBarViewCenterYConstant <= topLimit, direction == .up {


### PR DESCRIPTION
헤더뷰와 메뉴뷰의 오토 레이아웃을 수정했습니다.
* 헤더뷰는 탭바가 움직일 때에 맞춰서 top constraint를 변경했습니다.
* 메뉴뷰가 탭바에 가려지는 버그가 있어서 오토 레이아웃을 수정했습니다.

